### PR TITLE
Add weighted residual diagnostics and visual predictive check plotting

### DIFF
--- a/code/plotting-code/make-diagnostic-figures.R
+++ b/code/plotting-code/make-diagnostic-figures.R
@@ -45,6 +45,26 @@ for (i in 1:nsamp) {
   ###################################
   # 3.  One-to-one join & residuals
   ###################################
+  # Maximum value for each quantity (used in the weighted residual definition)
+  max_lookup <- dat %>%
+    group_by(Quantity) %>%
+    summarise(
+      ScalingMax = max(Value, na.rm = TRUE),
+      .groups = "drop"
+    ) %>%
+    mutate(
+      ScalingMax = ifelse(is.finite(ScalingMax), ScalingMax, NA_real_)
+    )
+
+  # Sample size for each (Scenario, Quantity) pair, mirroring the weights used
+  # in the least-squares objective function inside `fit_model_function()`.
+  n_lookup <- dat %>%
+    group_by(Scenario, Quantity) %>%
+    summarise(
+      SampleSize = dplyr::n(),
+      .groups = "drop"
+    )
+
   resid_df <- dat %>% # keep every data row (incl. replicates)
     inner_join(
       sim_long, # exact match on variable, time, scenario
@@ -57,6 +77,17 @@ for (i in 1:nsamp) {
       Scenario = factor(
         Scenario,
         levels = c("NoTreatment", "PanCytoVir10mg", "PanCytoVir100mg")
+      )
+    )
+  
+  resid_df <- resid_df %>%
+    left_join(max_lookup, by = "Quantity") %>%
+    left_join(n_lookup, by = c("Scenario", "Quantity")) %>%
+    mutate(
+      WeightedResidual = dplyr::if_else(
+        !is.na(ScalingMax) & ScalingMax > 0 & !is.na(SampleSize) & SampleSize > 0,
+        Residual / ScalingMax / sqrt(SampleSize),
+        NA_real_
       )
     )
 
@@ -75,44 +106,52 @@ for (i in 1:nsamp) {
   )
 
   ###################################
-  # 5.  Build the 3×3 residual plot
+  # 5.  Helper to build the 3×3 residual plot
   ###################################
-  p <- ggplot(resid_df, aes(x = Day, y = Residual)) +
-    geom_hline(yintercept = 0, linetype = "dashed", colour = "grey50") +
-    geom_point(alpha = 0.65, size = 2) +
-    facet_grid(
-      rows = vars(Quantity),
-      cols = vars(Scenario),
-      labeller = labeller(Quantity = var_labs, Scenario = scen_labs),
-      scales = "free_y" # tighter scale for IL-6 row
-    ) +
-    ylab("Residual") +
-    theme_bw(base_size = 14) +
-    theme(
-      axis.title.x = element_blank(), # master label added later
-      strip.background = element_blank(),
-      strip.text = element_text(size = 12)
-    )
+  build_residual_plot <- function(df, y_label) {
+    df <- df %>%
+      filter(!is.na(Residual))
+
+    if (nrow(df) == 0) {
+      stop("No residual values available for plotting. Check the weighting inputs.")
+    }
+
+    base_plot <- ggplot(df, aes(x = Day, y = Residual)) +
+      geom_hline(yintercept = 0, linetype = "dashed", colour = "grey50") +
+      geom_point(alpha = 0.65, size = 2) +
+      facet_grid(
+        rows = vars(Quantity),
+        cols = vars(Scenario),
+        labeller = labeller(Quantity = var_labs, Scenario = scen_labs),
+        scales = "free_y" # tighter scale for IL-6 row
+      ) +
+      ylab(y_label) +
+      theme_bw(base_size = 14) +
+      theme(
+        axis.title.x = element_blank(), # master label added later
+        strip.background = element_blank(),
+        strip.text = element_text(size = 12)
+      )
+
+    blank <- plot_spacer()
+
+    full_plot <-
+      base_plot /
+      blank + # stack blank row below
+      plot_layout(heights = c(1, 0.03)) & # tiny height for spacer
+      theme(plot.margin = margin(5.5, 5.5, 5.5, 5.5))
+
+    return(full_plot)
+  }
 
   ###################################
-  # 6.  Add a single centred x-axis
+  # 6.  Unweighted residual plot (original)
   ###################################
-  #   Patchwork trick: stack a blank
-  #   spacer row, then draw the label
-  ###################################
-  blank <- plot_spacer()
+  unweighted_plot <- build_residual_plot(resid_df, "Residual")
 
-  full_plot <-
-    p /
-    blank + # stack blank row below
-    plot_layout(heights = c(1, 0.03)) & # tiny height for spacer
-    theme(plot.margin = margin(5.5, 5.5, 5.5, 5.5))
-
-  # draw the plot and then the label
-  print(full_plot)
+  print(unweighted_plot)
   grid.text("Time (days)", y = unit(0.02, "npc"), gp = gpar(fontsize = 14))
 
-  # save to png file
   figname = paste0('residuals', i, '.png')
   png(
     here::here('results', 'figures', figname),
@@ -121,6 +160,28 @@ for (i in 1:nsamp) {
     units = 'in',
     res = 300
   )
-  print(full_plot)
+  print(unweighted_plot)
+  dev.off()
+
+  ###################################
+  # 7.  Weighted residual plot (matches the objective function weighting)
+  ###################################
+  weighted_resid_df <- resid_df %>%
+    mutate(Residual = WeightedResidual)
+
+  weighted_plot <- build_residual_plot(weighted_resid_df, "Weighted Residual")
+
+  print(weighted_plot)
+  grid.text("Time (days)", y = unit(0.02, "npc"), gp = gpar(fontsize = 14))
+
+  figname_weighted = paste0('residuals-weighted', i, '.png')
+  png(
+    here::here('results', 'figures', figname_weighted),
+    width = 8,
+    height = 5,
+    units = 'in',
+    res = 300
+  )
+  print(weighted_plot)
   dev.off()
 }

--- a/code/plotting-code/make-vpc-figures.R
+++ b/code/plotting-code/make-vpc-figures.R
@@ -1,0 +1,181 @@
+##########################################
+# make-vpc-figures.R
+##########################################
+#
+# Purpose --------------------------------------------------------------------
+# This script creates visual predictive check (VPC) figures for the calibrated
+# quantitative systems pharmacology (QSP) model.  The VPC compares the
+# experimental observations with the posterior predictive distribution that was
+# generated during the NPDE workflow (`run-npde-simulations.R`).  The plot shows
+# how well the model reproduces the magnitude and variability of the data across
+# all scenarios (No treatment, 10 mg/kg, 100 mg/kg) and outcome variables (virus
+# load, IL-6, and body weight).
+#
+# Overview --------------------------------------------------------------------
+# 1. Load the NPDE results, which contain both the observed data and the
+#    posterior predictive draws for every observation time.
+# 2. Summarise the predictive draws into point-wise quantiles (5th, 50th, and
+#    95th percentiles) for each scenario, quantity, and time point.
+# 3. Combine the summaries with the observed measurements to produce a faceted
+#    VPC figure that overlays the observations on the predictive intervals.
+# 4. Save the final figure to `results/figures/vpc-all.png` so that it is readily
+#    available for reports and manuscripts.
+#
+# The code favours clarity over brevity; explicit intermediate variables and
+# descriptive comments are used throughout to document each processing step.
+##########################################
+
+############################################
+## Packages
+############################################
+
+library(ggplot2)
+library(dplyr)
+library(tidyr)
+library(here)
+
+############################################
+## 1. Load NPDE results and perform safety checks
+############################################
+
+npde_path <- here::here("results", "output", "npde-results.Rds")
+if (!file.exists(npde_path)) {
+  stop(
+    "The file 'results/output/npde-results.Rds' is missing. Run 'run-npde-simulations.R' before generating VPC figures."
+  )
+}
+
+npde_results <- readRDS(npde_path)
+
+observed_data <- npde_results$observed_data
+prediction_draws <- npde_results$prediction_draws
+
+if (is.null(observed_data) || nrow(observed_data) == 0) {
+  stop("No observed data found in the NPDE results object.")
+}
+
+if (is.null(prediction_draws) || nrow(prediction_draws) == 0) {
+  stop("No posterior predictions available for the VPC. Check the NPDE simulations.")
+}
+
+# Ensure consistent factor ordering for scenarios and measured quantities.  The
+# NPDE helpers already enforce this, but we restate the logic here to make the
+# plotting script self-contained and explicit.
+scenario_levels <- c("NoTreatment", "PanCytoVir10mg", "PanCytoVir100mg")
+quantity_levels <- c("LogVirusLoad", "IL6", "Weight")
+
+observed_data <- observed_data %>%
+  mutate(
+    Scenario = factor(Scenario, levels = scenario_levels, ordered = TRUE),
+    Quantity = factor(Quantity, levels = quantity_levels, ordered = TRUE)
+  )
+
+prediction_draws <- prediction_draws %>%
+  mutate(
+    Scenario = factor(Scenario, levels = scenario_levels, ordered = TRUE),
+    Quantity = factor(Quantity, levels = quantity_levels, ordered = TRUE)
+  )
+
+############################################
+## 2. Summarise posterior predictive distribution
+############################################
+
+prediction_summary <- prediction_draws %>%
+  group_by(Scenario, Quantity, Day) %>%
+  summarise(
+    lower = stats::quantile(Prediction, probs = 0.05, na.rm = TRUE),
+    median = stats::quantile(Prediction, probs = 0.5, na.rm = TRUE),
+    upper = stats::quantile(Prediction, probs = 0.95, na.rm = TRUE),
+    .groups = "drop"
+  ) %>%
+  filter(!is.na(median))
+
+############################################
+## 3. Create the VPC figure
+############################################
+
+# Friendly facet labels reused in other plotting scripts.
+scen_labs <- c(
+  NoTreatment = "No Treatment",
+  PanCytoVir10mg = "10 mg/kg",
+  PanCytoVir100mg = "100 mg/kg"
+)
+var_labs <- c(
+  LogVirusLoad = "Log Virus Load",
+  IL6 = "IL-6",
+  Weight = "Weight"
+)
+
+# Palette and shapes chosen to match existing diagnostic figures (Okabe–Ito).
+col_vals <- setNames(
+  c("#0072B2", "#009E73", "#D55E00")[seq_along(scenario_levels)],
+  scenario_levels
+)
+shape_vals <- setNames(c(16, 17, 15)[seq_along(scenario_levels)], scenario_levels)
+
+vpc_plot <- ggplot() +
+  geom_ribbon(
+    data = prediction_summary,
+    aes(x = Day, ymin = lower, ymax = upper, fill = Scenario),
+    alpha = 0.25,
+    colour = NA
+  ) +
+  geom_line(
+    data = prediction_summary,
+    aes(x = Day, y = median, colour = Scenario),
+    size = 1
+  ) +
+  geom_point(
+    data = observed_data,
+    aes(x = Day, y = Value, colour = Scenario, shape = Scenario),
+    size = 2,
+    alpha = 0.8
+  ) +
+  facet_grid(
+    rows = vars(Quantity),
+    cols = vars(Scenario),
+    labeller = labeller(Quantity = var_labs, Scenario = scen_labs),
+    scales = "free_y"
+  ) +
+  scale_color_manual(
+    values = col_vals,
+    name = "Scenario:",
+    labels = scen_labs
+  ) +
+  scale_shape_manual(
+    values = shape_vals,
+    name = "Scenario:",
+    labels = scen_labs
+  ) +
+  scale_fill_manual(values = col_vals, guide = "none") +
+  xlab("Time (days)") +
+  ylab("Observed and Predicted Values") +
+  theme_bw(base_size = 14) +
+  theme(
+    strip.background = element_blank(),
+    strip.text = element_text(size = 12),
+    legend.position = "top"
+  )
+
+############################################
+## 4. Save the figure
+############################################
+
+fig_dir <- here::here("results", "figures")
+if (!dir.exists(fig_dir)) {
+  dir.create(fig_dir, recursive = TRUE)
+}
+
+png(
+  filename = file.path(fig_dir, "vpc-all.png"),
+  width = 10,
+  height = 8,
+  units = "in",
+  res = 300
+)
+print(vpc_plot)
+dev.off()
+
+##########################################
+# End of script
+##########################################


### PR DESCRIPTION
## Summary
- compute objective-function weights inside the diagnostic residual scripts and export both unweighted and weighted residual figures
- extend the combined diagnostic plotting workflow with weighted residual views while preserving existing styling
- add a dedicated script that builds and saves visual predictive check figures from the NPDE simulation results

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903c9ff262c832fb72e8e09edba67be